### PR TITLE
Fix permissions for service account after upgrades

### DIFF
--- a/Source/Applications/openECA/openECASetup/CustomFeatureTree.wxs
+++ b/Source/Applications/openECA/openECASetup/CustomFeatureTree.wxs
@@ -16,10 +16,6 @@ Maintenance dialog sequence:
  - WixUI_MaintenanceTypeDlg
  - WixUI_CustomizeDlg
  - WixUI_VerifyReadyDlg
-
-Patch dialog sequence:
- - WixUI_WelcomeDlg
- - WixUI_VerifyReadyDlg
 -->
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
@@ -44,7 +40,6 @@ Patch dialog sequence:
       <Publish Dialog="CustomExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
 
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">NOT Installed</Publish>
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
 
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg">LicenseAccepted = "1"</Publish>
@@ -54,8 +49,7 @@ Patch dialog sequence:
       <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg" Order="1">NOT Installed OR WixUI_InstallMode = "Change"</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="3">Installed AND PATCH</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT(WixUI_InstallMode = "Change")</Publish>
 
       <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
 

--- a/Source/Applications/openECA/openECASetup/openECASetup.wxs
+++ b/Source/Applications/openECA/openECASetup/openECASetup.wxs
@@ -142,6 +142,7 @@
     <Property Id="INSTALLCLIENTTOOLSFEATURE" Secure="yes" />
 
     <Property Id="SERVICENAME" Value="$(var.openECA.TargetName)" />
+    <Property Id="SERVICEACCOUNT" Secure="yes" />
     <Property Id="CLIENTNAME" Value="$(var.openECAClient.TargetName)" />
     <Property Id="SERVICEPASSWORD" Hidden="yes" />
     <Property Id="HTTPSERVICEPORTS" Value="6061,6062,6161,6162,6362,6462,5023" />

--- a/Source/Applications/openECA/openECASetup/openECASetup.wxs
+++ b/Source/Applications/openECA/openECASetup/openECASetup.wxs
@@ -100,10 +100,22 @@
       <UIRef Id="WixUI_ErrorProgressText" />
       <DialogRef Id="CompanyInfoDialog" />
       <DialogRef Id="ServiceAccountDialog" />
-      <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="ServiceAccountDialog"><![CDATA[&openECAFeature=3]]></Publish>
-      <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg"><![CDATA[NOT(&openECAFeature=3)]]></Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CompanyInfoDialog">(NOT Installed OR WixUI_InstallMode = "Change") AND <![CDATA[&openECAFeature=3]]></Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">(NOT Installed OR WixUI_InstallMode = "Change") AND <![CDATA[NOT(&openECAFeature=3)]]></Publish>
+
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLSERVICEFEATURE" Value="1" Order="7"><![CDATA[&openECAFeature=3 OR (!openECAFeature=3 AND &openECAFeature=-1)]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLSERVICEFEATURE" Order="7"><![CDATA[NOT(&openECAFeature=3 OR (!openECAFeature=3 AND &openECAFeature=-1))]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLMANAGERFEATURE" Value="1" Order="7"><![CDATA[&openECAManagerFeature=3 OR (!openECAManagerFeature=3 AND &openECAManagerFeature=-1)]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLMANAGERFEATURE" Order="7"><![CDATA[NOT(&openECAManagerFeature=3 OR (!openECAManagerFeature=3 AND &openECAManagerFeature=-1))]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLCONSOLEFEATURE" Value="1" Order="7"><![CDATA[&openECAConsoleFeature=3 OR (!openECAConsoleFeature=3 AND &openECAConsoleFeature=-1)]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLCONSOLEFEATURE" Order="7"><![CDATA[NOT(&openECAConsoleFeature=3 OR (!openECAConsoleFeature=3 AND &openECAConsoleFeature=-1))]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLTOOLSFEATURE" Value="1" Order="7"><![CDATA[&openECAToolsFeature=3 OR (!openECAToolsFeature=3 AND &openECAToolsFeature=-1)]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLTOOLSFEATURE" Order="7"><![CDATA[NOT(&openECAToolsFeature=3 OR (!openECAToolsFeature=3 AND &openECAToolsFeature=-1))]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLCLIENTTOOLSFEATURE" Value="1" Order="7"><![CDATA[&ClientTools=3 OR (!ClientTools=3 AND &ClientTools=-1)]]></Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Property="INSTALLCLIENTTOOLSFEATURE" Order="7"><![CDATA[NOT(&ClientTools=3 OR (!ClientTools=3 AND &ClientTools=-1))]]></Publish>
+
+      <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="ServiceAccountDialog" Order="8">INSTALLSERVICEFEATURE</Publish>
+      <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="8">NOT(INSTALLSERVICEFEATURE)</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CompanyInfoDialog">INSTALLSERVICEFEATURE</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">NOT(INSTALLSERVICEFEATURE)</Publish>
       <Publish Dialog="CustomExitDialog" Control="Finish" Event="DoAction" Value="StartCSUProcessAction">WIXUI_CUSTOMEXITDIALOGOPTIONALCHECKBOX = 1</Publish>
     </UI>
 
@@ -123,6 +135,12 @@
     <Icon Id="APPPDCImporter.ico.exe" SourceFile="$(var.ProjectDir)\APPPDCImporter.exe"/>
     <Icon Id="SELPDCImporter.ico.exe" SourceFile="$(var.ProjectDir)\SELPDCImporter.exe"/>
 
+    <Property Id="INSTALLSERVICEFEATURE" Secure="yes" />
+    <Property Id="INSTALLMANAGERFEATURE" Secure="yes" />
+    <Property Id="INSTALLCONSOLEFEATURE" Secure="yes" />
+    <Property Id="INSTALLTOOLSFEATURE" Secure="yes" />
+    <Property Id="INSTALLCLIENTTOOLSFEATURE" Secure="yes" />
+
     <Property Id="SERVICENAME" Value="$(var.openECA.TargetName)" />
     <Property Id="CLIENTNAME" Value="$(var.openECAClient.TargetName)" />
     <Property Id="SERVICEPASSWORD" Hidden="yes" />
@@ -136,11 +154,24 @@
     <Property Id="REGSERVICESTARTVALUE">
       <RegistrySearch Id="ServiceStartRegSearch" Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\[SERVICENAME]" Name="Start" Type="raw" />
     </Property>
+
     <SetProperty Action="SetServiceStartDefault" Id="SERVICESTART" After="AppSearch" Value="#2" Sequence="first"><![CDATA[NOT REGSERVICESTARTVALUE]]></SetProperty>
     <SetProperty Action="SetServiceStartRegistry" Id="SERVICESTART" After="AppSearch" Value="[REGSERVICESTARTVALUE]" Sequence="first"><![CDATA[REGSERVICESTARTVALUE]]></SetProperty>
     <SetProperty Action="SetServiceAccountDefault" Id="SERVICEACCOUNT" After="AppSearch" Value="NT SERVICE\[SERVICENAME]" Sequence="first"><![CDATA[NOT REGSERVICEACCOUNT]]></SetProperty>
     <SetProperty Action="SetServiceAccountRegistry" Id="SERVICEACCOUNT" After="AppSearch" Value="[REGSERVICEACCOUNT]" Sequence="first"><![CDATA[REGSERVICEACCOUNT]]></SetProperty>
     <SetProperty Id="PROCESSSTARTINFO" Value="FileName={[#ConfigurationSetupUtility.exe]};Arguments=-install;UseShellExecute=True;Verb=runas" After="ExecuteAction" Sequence="ui" />
+
+    <SetProperty Action="INSTALLSERVICEFEATURE0" Id="INSTALLSERVICEFEATURE" Value="1" After="CostFinalize" Sequence="both"><![CDATA[&openECAFeature=3 OR (!openECAFeature=3 AND &openECAFeature=-1)]]></SetProperty>
+    <SetProperty Action="INSTALLSERVICEFEATURE1" Id="INSTALLSERVICEFEATURE" Value="" After="CostFinalize" Sequence="both"><![CDATA[NOT(&openECAFeature=3 OR (!openECAFeature=3 AND &openECAFeature=-1))]]></SetProperty>
+    <SetProperty Action="INSTALLMANAGERFEATURE0" Id="INSTALLMANAGERFEATURE" Value="1" After="CostFinalize" Sequence="both"><![CDATA[&openECAManagerFeature=3 OR (!openECAManagerFeature=3 AND &openECAManagerFeature=-1)]]></SetProperty>
+    <SetProperty Action="INSTALLMANAGERFEATURE1" Id="INSTALLMANAGERFEATURE" Value="" After="CostFinalize" Sequence="both"><![CDATA[NOT(&openECAManagerFeature=3 OR (!openECAManagerFeature=3 AND &openECAManagerFeature=-1))]]></SetProperty>
+    <SetProperty Action="INSTALLCONSOLEFEATURE0" Id="INSTALLCONSOLEFEATURE" Value="1" After="CostFinalize" Sequence="both"><![CDATA[&openECAConsoleFeature=3 OR (!openECAConsoleFeature=3 AND &openECAConsoleFeature=-1)]]></SetProperty>
+    <SetProperty Action="INSTALLCONSOLEFEATURE1" Id="INSTALLCONSOLEFEATURE" Value="" After="CostFinalize" Sequence="both"><![CDATA[NOT(&openECAConsoleFeature=3 OR (!openECAConsoleFeature=3 AND &openECAConsoleFeature=-1))]]></SetProperty>
+    <SetProperty Action="INSTALLTOOLSFEATURE0" Id="INSTALLTOOLSFEATURE" Value="1" After="CostFinalize" Sequence="both"><![CDATA[&openECAToolsFeature=3 OR (!openECAToolsFeature=3 AND &openECAToolsFeature=-1)]]></SetProperty>
+    <SetProperty Action="INSTALLTOOLSFEATURE1" Id="INSTALLTOOLSFEATURE" Value="" After="CostFinalize" Sequence="both"><![CDATA[NOT(&openECAToolsFeature=3 OR (!openECAToolsFeature=3 AND &openECAToolsFeature=-1))]]></SetProperty>
+    <SetProperty Action="INSTALLCLIENTTOOLSFEATURE0" Id="INSTALLCLIENTTOOLSFEATURE" Value="1" After="CostFinalize" Sequence="both"><![CDATA[&ClientTools=3 OR (!ClientTools=3 AND &ClientTools=-1)]]></SetProperty>
+    <SetProperty Action="INSTALLCLIENTTOOLSFEATURE1" Id="INSTALLCLIENTTOOLSFEATURE" Value="" After="CostFinalize" Sequence="both"><![CDATA[NOT(&ClientTools=3 OR (!ClientTools=3 AND &ClientTools=-1))]]></SetProperty>
+
     <WixVariable Id="WixUIBannerBmp" Value="$(var.ProjectDir)\openECASetupBanner.bmp" />
     <WixVariable Id="WixUIDialogBmp" Value="$(var.ProjectDir)\openECASetupDialog.bmp" />
     <WixVariable Id="WixUILicenseRtf" Value="$(var.ProjectDir)\INSTALL_LICENSE.rtf" />
@@ -172,14 +203,14 @@
     </UI>
 
     <InstallExecuteSequence>
-      <Custom Action="CompanyInfoAction.SetProperty" After="InstallFiles">NOT REMOVE AND <![CDATA[&openECAFeature=3]]></Custom>
-      <Custom Action="CompanyInfoAction" After="CompanyInfoAction.SetProperty">NOT REMOVE AND <![CDATA[&openECAFeature=3]]></Custom>
-      <Custom Action="ClientCompanyInfoAction.SetProperty" After="CompanyInfoAction">NOT REMOVE AND <![CDATA[&openECAFeature=3]]></Custom>
-      <Custom Action="ClientCompanyInfoAction" After="ClientCompanyInfoAction.SetProperty">NOT REMOVE AND <![CDATA[&openECAFeature=3]]></Custom>
-      <Custom Action="ConfigureServiceAction.SetProperty" After="InstallServices">NOT REMOVE AND <![CDATA[&openECAFeature=3]]></Custom>
-      <Custom Action="ConfigureServiceAction" After="ConfigureServiceAction.SetProperty">NOT REMOVE AND <![CDATA[&openECAFeature=3]]></Custom>
-      <Custom Action="ServiceAccountAction.SetProperty" After="ConfigureServiceAction">NOT REMOVE</Custom>
-      <Custom Action="ServiceAccountAction" After="ServiceAccountAction.SetProperty">NOT REMOVE</Custom>
+      <Custom Action="CompanyInfoAction.SetProperty" After="InstallFiles">INSTALLSERVICEFEATURE</Custom>
+      <Custom Action="CompanyInfoAction" After="CompanyInfoAction.SetProperty">INSTALLSERVICEFEATURE</Custom>
+      <Custom Action="ClientCompanyInfoAction.SetProperty" After="CompanyInfoAction">INSTALLCLIENTTOOLSFEATURE</Custom>
+      <Custom Action="ClientCompanyInfoAction" After="ClientCompanyInfoAction.SetProperty">INSTALLCLIENTTOOLSFEATURE</Custom>
+      <Custom Action="ConfigureServiceAction.SetProperty" After="InstallServices"><![CDATA[&openECAFeature=3]]></Custom>
+      <Custom Action="ConfigureServiceAction" After="ConfigureServiceAction.SetProperty"><![CDATA[&openECAFeature=3]]></Custom>
+      <Custom Action="ServiceAccountAction.SetProperty" After="ConfigureServiceAction">INSTALLSERVICEFEATURE</Custom>
+      <Custom Action="ServiceAccountAction" After="ServiceAccountAction.SetProperty">INSTALLSERVICEFEATURE</Custom>
       <Custom Action="NetFxExecuteNativeImageCommitInstall" After="NetFxExecuteNativeImageUninstall">0</Custom>
       <Custom Action="NetFxExecuteNativeImageInstall" After="NetFxExecuteNativeImageCommitInstall" />
       <!-- Set write registry values sequence after service install but before service start to restore original service start mode -->


### PR DESCRIPTION
The service account loses permissions to start and stop the service after using the installer to upgrade the system. This PR fixes that by running `ServiceAccountAction` so long as the service is still installed.